### PR TITLE
Refactor livecycle to allow garbage collection on detach

### DIFF
--- a/img-loader.html
+++ b/img-loader.html
@@ -75,7 +75,7 @@ all `img-loader` code comes from <a href="https://github.com/PolymerElements/iro
       detached(){
         var img = this.$.img;
         img.onload = img.onerror = null;
-      }
+      },
 
       _srcChanged: function(newSrc, oldSrc) {
         var newResolvedSrc = this._resolveSrc(newSrc);

--- a/img-loader.html
+++ b/img-loader.html
@@ -51,7 +51,7 @@ all `img-loader` code comes from <a href="https://github.com/PolymerElements/iro
         }
       },
 
-      ready: function() {
+      attached: function() {
         var img = this.$.img;
 
         img.onload = function() {
@@ -71,6 +71,11 @@ all `img-loader` code comes from <a href="https://github.com/PolymerElements/iro
 
         this._resolvedSrc = '';
       },
+
+      detached(){
+        var img = this.$.img;
+        img.onload = img.onerror = null;
+      }
 
       _srcChanged: function(newSrc, oldSrc) {
         var newResolvedSrc = this._resolveSrc(newSrc);

--- a/img-pan-zoom.html
+++ b/img-pan-zoom.html
@@ -190,9 +190,7 @@ Custom property | Description | Default
       },
 
       detached: function(){
-        if(this.viewer) {
-          this.destroy();
-        }
+        this.destroy();
       },
 
       // Init openseadragon
@@ -226,6 +224,9 @@ Custom property | Description | Default
 
       //Function to destroy the viewer and clean up everything created by OpenSeadragon.
       destroy: function() {
+        if(this.viewer == null){
+          return;
+        }
         this.viewer.destroy();
         this.viewer = null;
       },

--- a/img-pan-zoom.html
+++ b/img-pan-zoom.html
@@ -179,12 +179,19 @@ Custom property | Description | Default
             node: this.$.viewer
           }
         }
+      },
 
-
+      attached: function(){
         // Init openseadragon if we are using a deep zoom image
         if (this.dzi) {
           // Add src changed observer
           this._initOpenSeadragon();
+        }
+      },
+
+      detached: function(){
+        if(this.viewer) {
+          this.destroy();
         }
       },
 
@@ -215,13 +222,12 @@ Custom property | Description | Default
           maxZoomPixelRatio: this.maxZoomPixelRatio,
           tileSources: tileSources
         });
-
-        this.init = true;
       },
 
       //Function to destroy the viewer and clean up everything created by OpenSeadragon.
       destroy: function() {
         this.viewer.destroy();
+        this.viewer = null;
       },
 
       // Zoom in
@@ -257,20 +263,17 @@ Custom property | Description | Default
 
 
       _srcChanged: function(){
-        if (this.dzi && this.init) {
-          // add tiled image
-          this._addTiledImage();
+        if(!this.dzi || this.viewer == null ){
+          return;
         }
+        this._addTiledImage()
       },
       // Add loaded images to viewer
       _loadedChanged: function(){
-        if (this.loaded) {
-          if (!this.init) {
-            this._initOpenSeadragon();
-          }else {
-            this._addImage();
-          }
+        if(!this.loaded) {
+          return;
         }
+        this.viewer == null ? this._initOpenSeadragon() : this._addImage();
       },
 
       _addImage: function(){


### PR DESCRIPTION
Refactor livecycle to allow garbage collection on detach.
In `img-pan-zoom` on detach destroy OpenSeadragon viewer and remove reference to it.
In `img-loader` on detach remove  `onload` and `onerror` callbacks. 